### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "contactcenterinsights",
     "name_pretty": "Contact Center AI Insights API",
     "product_documentation": "https://cloud.google.com/contact-center/insights/docs",
-    "client_documentation": "https://googleapis.dev/python/contactcenterinsights/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/contactcenterinsights/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python client for `Contact Center AI Insights`_
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-contact-center-insights.svg
    :target: https://pypi.org/project/google-cloud-contact-center-insights/
 .. _Contact Center AI Insights: https://cloud.google.com/contact-center/insights/docs
-.. _Client Library Documentation: https://googleapis.dev/python/contactcenterinsights/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/contactcenterinsights/latest
 .. _Product Documentation:  https://cloud.google.com/contact-center/insights/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.